### PR TITLE
Modernize packaging: require Python 3.10+, upgrade markdown, remove Py2 legacy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import os
@@ -15,11 +15,11 @@ import octoprint_setuptools  # noqa: F401,E402
 # ----------------------------------------------------------------------------------------
 
 # Supported python versions
-# we test against 2.7, 3.6 and 3.7, so that's what we'll mark as supported
-PYTHON_REQUIRES = ">=2.7.9, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, <4"
+# Runtime baseline for this fork/container
+PYTHON_REQUIRES = ">=3.10,<4"
 
 # Requirements for setup.py
-SETUP_REQUIRES = ["markdown>=3.1,<3.2"]  # newer versions require Python 3
+SETUP_REQUIRES = ["markdown>=3.7,<4"]
 
 # Requirements for our application
 INSTALL_REQUIRES = [
@@ -30,8 +30,8 @@ INSTALL_REQUIRES = [
     # the following dependencies are non trivial to update since later versions
     # introduce backwards incompatible changes that might affect plugins, or due to
     # other observed problems
-    "markupsafe>=1.1,<2.0",  # Jinja dependency, newer versions require Python 3
-    "markdown>=3.1,<3.2",  # newer versions require Python 3
+    "markupsafe>=1.1,<2.0",  # pinned for Flask/Jinja2 compatibility in this codebase
+    "markdown>=3.7,<4",
     "wrapt>=1.12.1,<1.13",  # newer versions fail to build on OctoPi 0.15
     # anything below this should be checked on releases for new versions
     "flask>=1.1.4,<2",  # newer versions require Python 3
@@ -64,24 +64,7 @@ INSTALL_REQUIRES = [
     "blinker>=1.4,<2",  # dependency of flask_principal
 ]
 
-# Python 2 specific requirements
-INSTALL_REQUIRES_PYTHON2 = [
-    "feedparser>=5.2.1,<6",  # newer versions require Python 3
-    "tornado==5.1.1",  # newer versions require Python 3
-    "futures>=3.3,<4",
-    "monotonic>=1.6,<2",
-    "scandir>=1.10,<2",
-    "chainmap>=1.0.3,<2",
-    "typing>=3.10.0.0,<4",
-    "enum34>=1.1.10,<1.2",
-    "frozendict==1.2",  # newer versions from different maintainer require Python 3
-    "colorlog<5",  # newer versions require Python 3
-    # vendor bundled dependencies
-    "unidecode<1.3",  # dependency of awesome-slugify, newer versions require Python 3
-    "regex<2022.1.18",  # dependency of awesome-slugify, newer versions require Python 3
-]
-
-# Python 3 specific requirements
+# Runtime-specific requirements
 INSTALL_REQUIRES_PYTHON3 = [
     "feedparser>=6.0.8,<7",
     "tornado>=6,<7",  # tornado < 6 is incompatible with Python 3.10
@@ -127,25 +110,9 @@ EXTRA_REQUIRES = {
 # Dependency links for any of the aforementioned dependencies
 DEPENDENCY_LINKS = []
 
-# adapted from https://hynek.me/articles/conditional-python-dependencies/
-if int(setuptools.__version__.split(".", 1)[0]) < 18:
-    # no bdist_wheel support for setuptools < 18 since we build universal wheels and our optional dependencies
-    # would get lost there
-    assert "bdist_wheel" not in sys.argv
-
-    # add optional dependencies for setuptools versions < 18 that don't yet support environment markers
-    if sys.version_info[0] < 3:
-        INSTALL_REQUIRES += INSTALL_REQUIRES_PYTHON2
-    else:
-        INSTALL_REQUIRES += INSTALL_REQUIRES_PYTHON3
-
-    if sys.platform == "darwin":
-        INSTALL_REQUIRES += INSTALL_REQUIRES_OSX
-else:
-    # environment markers supported
-    EXTRA_REQUIRES[":python_version < '3'"] = INSTALL_REQUIRES_PYTHON2
-    EXTRA_REQUIRES[":python_version >= '3'"] = INSTALL_REQUIRES_PYTHON3
-    EXTRA_REQUIRES[":sys_platform == 'darwin'"] = INSTALL_REQUIRES_OSX
+# environment markers supported by modern setuptools/pip
+EXTRA_REQUIRES[":python_version >= '3.10'"] = INSTALL_REQUIRES_PYTHON3
+EXTRA_REQUIRES[":sys_platform == 'darwin'"] = INSTALL_REQUIRES_OSX
 
 # -----------------------------------------------------------------------------------------------------------------------
 # Anything below here is just command setup and general setup configuration


### PR DESCRIPTION
### Motivation
- Bring packaging metadata and setup logic in line with the project's runtime baseline by moving to Python `>=3.10,<4` and dropping legacy Python 2 handling.
- Remove the setuptools/workaround churn that existed only to support very old `markdown` versions and replace it by requiring a modern `markdown` that no longer depends on `pkg_resources` from `setuptools`.

### Description
- Updated the script shebang to `#!/usr/bin/env python3` to match the new baseline.
- Set `PYTHON_REQUIRES = ">=3.10,<4"` to express the supported runtime.
- Bumped `SETUP_REQUIRES` and runtime `markdown` requirement to `"markdown>=3.7,<4"` and ensured the runtime `INSTALL_REQUIRES` contains the same modern `markdown` range.
- Removed the entire Python 2 specific dependency list and the old `setuptools < 18` conditional logic, replacing it with simple environment markers: `EXTRA_REQUIRES[":python_version >= '3.10'"] = INSTALL_REQUIRES_PYTHON3` and `EXTRA_REQUIRES[":sys_platform == 'darwin'"] = INSTALL_REQUIRES_OSX`.
- Kept other existing runtime dependency pins intact and preserved the md-to-html build step and versioneer/octoprint setuptools integration.

### Testing
- Ran `python -m py_compile setup.py` which completed successfully.
- Installed `pre-commit` via `python -m pip install pre-commit` successfully and attempted `pre-commit run --all-files`, which failed in this environment due to a remote fetch error fetching `https://gitlab.com/pycqa/flake8` (`fatal: could not read Username for 'https://gitlab.com': No such device or address`), so hooks could not be fully validated here.
- The change was committed locally with a descriptive message after these checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698dc2143fc0832d843f3ec7db80f799)